### PR TITLE
Add usage comments to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
+# Dockerfile for a minimal Flask web application
+# Builds a slim Python image and runs a simple app
 FROM python:3.12-slim
 
 # Ensure pip is installed and up to date, then install Flask
 RUN python -m ensurepip && pip install --no-cache-dir --upgrade pip Flask
 
+# Set the working directory for the application
 WORKDIR /app
+
+# Copy the application source
 COPY app.py .
 
+# Default command to run the Flask app
 CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- add header comments explaining purpose of Dockerfile
- document working directory, copy step and default command

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840f350ed088327bbf371d925d5c781